### PR TITLE
Added 4 lines missing from get_media() in forms.py

### DIFF
--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -22,9 +22,12 @@ class RecurrenceWidget(forms.Textarea):
         js = [
             'admin/js/vendor/jquery/jquery%s.js' % extra,
             'admin/js/jquery.init.js',
+            'admin/jsi18n',
             staticfiles_storage.url('recurrence/js/recurrence.js'),
             staticfiles_storage.url('recurrence/js/recurrence-widget.js'),
             staticfiles_storage.url('recurrence/js/recurrence-widget.init.js'),
+            staticfiles_storage.url('admin/js/core.js')
+            
         ]
         i18n_media = find_recurrence_i18n_js_catalog()
         if i18n_media:
@@ -34,6 +37,8 @@ class RecurrenceWidget(forms.Textarea):
             js=js, css={
                 'all': (
                     staticfiles_storage.url('recurrence/css/recurrence.css'),
+                    staticfiles_storage.url('admin/css/base.css'),
+                    staticfiles_storage.url('admin/css/forms.css'),
                 ),
             },
         )

--- a/recurrence/forms.py
+++ b/recurrence/forms.py
@@ -27,7 +27,6 @@ class RecurrenceWidget(forms.Textarea):
             staticfiles_storage.url('recurrence/js/recurrence-widget.js'),
             staticfiles_storage.url('recurrence/js/recurrence-widget.init.js'),
             staticfiles_storage.url('admin/js/core.js')
-            
         ]
         i18n_media = find_recurrence_i18n_js_catalog()
         if i18n_media:


### PR DESCRIPTION
The original issue was described here:
https://github.com/django-recurrence/django-recurrence/issues/170#issuecomment-710028328

Django-recurrence widget was found to be functioning properly in the Django Admin, however when integrating the widget into a custom Model Form the buttons had no functionality when clicked. It was found that 2 Javascript tags and 2 CSS tags were missing that shouldve been loaded automatically through {% load static %} and {{ form.media }}. Looking through the source code it seems that 4 lines were missing from the get_media() method in forms.py which otherwise need to be loaded manually by anyone using the widget to get proper functionality.