### PR TITLE
Deserialize recurrences with multiple comma-separated exclusion dates

### DIFF
--- a/recurrence/base.py
+++ b/recurrence/base.py
@@ -1081,7 +1081,8 @@ def deserialize(text, include_dtstart=True):
         elif label == u'RDATE':
             rdates.append(deserialize_dt(param_text))
         elif label == u'EXDATE':
-            exdates.append(deserialize_dt(param_text))
+            for item in param_text.split(','):
+                exdates.append(deserialize_dt(item))
 
     return Recurrence(dtstart, dtend, rrules, exrules, rdates, exdates, include_dtstart)
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -114,3 +114,12 @@ def test_bug_in_count_and_until_rule_serialization():
 
     # Note that we've got no UNTIL value here
     assert 'RRULE:FREQ=WEEKLY;COUNT=7' == serialized
+
+
+def test_comma_separated_exdates():
+    exdates = [datetime(2022, 3, 14, 21, 0, 0), datetime(2022, 3, 13, 21, 0, 0)]
+    recurrence_ = Recurrence(exdates=exdates)
+    text = 'EXDATE:20220314T210000Z,20220313T210000Z'
+
+    deserialized = recurrence.deserialize(text)
+    assert recurrence_ == deserialized


### PR DESCRIPTION
There's an issue #158 concerning this problem. I ran into it recently too. It looks like a small fix that deserves to be implemented.