### PR TITLE
change label font color to white in dark mode

### DIFF
--- a/recurrence/static/recurrence/css/recurrence.css
+++ b/recurrence/static/recurrence/css/recurrence.css
@@ -23,6 +23,12 @@ div.recurrence-widget a.recurrence-label {
     color: black;
 }
 
+@media (prefers-color-scheme: dark) {
+  div.recurrence-widget a.recurrence-label {
+    color: white;
+  }
+}
+
 div.recurrence-widget .remove,
 div.recurrence-widget .remove:link,
 div.recurrence-widget .remove:visited {


### PR DESCRIPTION
A cosmetic PR that improves readability of the admin widget in dark mode.

Before:

<img width="233" alt="image" src="https://user-images.githubusercontent.com/6090492/189732869-7dc49f93-b185-4ede-ac3d-94ced8154af3.png">

After:

<img width="228" alt="image" src="https://user-images.githubusercontent.com/6090492/189732934-e3e82792-72c3-4184-a20b-65abb84145ee.png">
