### PR TITLE
fix: update import statement to align with latest version of Django

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ following to your project ``urls.py`` file:
 .. code-block:: python
 
     import django
-    from django.conf.urls import url
+    from django.urls import re_path as url
     from django.views.i18n import JavaScriptCatalog
 
     # Your normal URLs here...


### PR DESCRIPTION
Fix: The current installation instructions produce an error as described in [this PR](https://github.com/Tivix/django-rest-auth/issues/659). Updating the import statement to align with latest version of Django.