### PR TITLE
Revert "Add Python 3.11 to CI, tox, and trove classifiers"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
         django-version: ['2.2', '3.2', '4.0']
         include:
           # Tox configuration for documentation environment
@@ -27,9 +27,6 @@ jobs:
             django-version: 'main'
             experimental: true
           - python-version: '3.10'
-            django-version: 'main'
-            experimental: true
-          - python-version: '3.11'
             django-version: 'main'
             experimental: true
         exclude:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ Then, make sure ``recurrence`` is in your ``INSTALLED_APPS`` setting:
 Supported Django and Python versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently, django-recurrence supports Python 3.6, 3.7, 3.8, 3.9, 3.10, and 3.11.
+Currently, django-recurrence supports Python 3.6, 3.7, 3.8, 3.9, and 3.10.
 
 django-recurrence is currently tested with django 2.2, 3.2, and 4.0
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 envlist =
   py37-djdocs
   py37-djqa
-  py{37,38,39,310,311,py38}-dj22
-  py{37,38,39,310,311,py38}-dj32
-  py{38,39,310,311,py38}-dj40
-  py{38,39,310,311,py38}-djmain
+  py{37,38,39,310,py38}-dj22
+  py{37,38,39,310,py38}-dj32
+  py{38,39,310,py38}-dj40
+  py{38,39,310,py38}-djmain
 
 [gh-actions]
 python =
@@ -13,7 +13,6 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
-  3.11: py311
   pypy-3.8: pypy38
 
 [gh-actions:env]


### PR DESCRIPTION
Reverts jazzband/django-recurrence#241

Will have to do some maintenance to solve pipeline fails.